### PR TITLE
Various fixes

### DIFF
--- a/autosetup.sh
+++ b/autosetup.sh
@@ -34,11 +34,11 @@ DisableLEDS=0    #RPI2 or RPI3 only
 #User-specific settings
 HomeFolder='/home/osmc'    #make sure you enter your correct homefolder here!
 MediaFolder='/media/yourusbdrive'    #enter the path+root of your USB drive or location of your NFS mount ('/mnt/name') 
-dyndnsurl="http://sync.afraid.org/u/your-url-id/"
-TraktUser=yourtraktusername
-TransmissionUser=desiredusername
-TransmissionPw=desiredpw
-SpotifyDeviceName=YourDeviceName   # pick a name, it will show up in the Spotify app on your phone or computer.
+dyndnsurl='http://sync.afraid.org/u/your-url-id/'
+TraktUser='yourtraktusername'
+TransmissionUser='desiredusername'
+TransmissionPw='desiredpw'
+SpotifyDeviceName='YourDeviceName'   # pick a name, it will show up in the Spotify app on your phone or computer.
 
 
 ##########################################
@@ -48,7 +48,7 @@ SpotifyDeviceName=YourDeviceName   # pick a name, it will show up in the Spotify
 ##########################################
 # Disable LEDs on RPi2 or RPi3 (Power and Activity LEDS, network leds cannot be disabled)
 if [ "DisableLEDS" = "1" ] ; then
-sudo bash -c 'cat >> $HomeFolder/.kodi/userdata/sources.xml' << EOF
+sudo bash -c "cat >> $HomeFolder/.kodi/userdata/sources.xml" << EOF
 # Disable the ACT LED.
 dtparam=act_led_trigger=none
 dtparam=act_led_activelow=off
@@ -62,7 +62,7 @@ fi
 
 # Add media to Kodi
 if [ "$AddMediaToKodi" = "1" ] ; then
-sudo bash -c 'cat > $HomeFolder/.kodi/userdata/sources.xml' << EOF
+sudo bash -c "cat > $HomeFolder/.kodi/userdata/sources.xml" << EOF
 <sources>
     <programs>
         <default pathversion="1"></default>
@@ -116,14 +116,14 @@ fi
 
 # Configure Transmission and set it to send finished downloads to Kodi library
 if [ "$Transmission" = "1" ] ; then
-sudo service transmission stop
+sudo systemctl stop transmission
 cd $HomeFolder/.config/transmission-daemon
 curl -O https://rawgit.com/zilexa/transmission/master/settings.json
 sed -i "s/osmc/$TransmissionUser/g" $HomeFolder/.config/transmission-daemon/settings.json
 sed -i "s/OSMC/$TransmissionPw/g" $HomeFolder/.config/transmission-daemon/settings.json
 sed -i 's|MediaFolder|'$MediaFolder'|g' $HomeFolder/.config/transmission-daemon/settings.json
 sudo chmod 755 settings.json
-sudo service transmission start
+sudo systemctl start transmission
 fi
 
 
@@ -153,7 +153,7 @@ fi
 
 
 # install SyncThing
-if [ "$SycnThing" = "1" ] ; then
+if [ "$SyncThing" = "1" ] ; then
 sudo curl -s https://syncthing.net/release-key.txt | sudo apt-key add -
 echo "deb http://apt.syncthing.net/ syncthing release" | sudo tee /etc/apt/sources.list.d/syncthing.list
 sudo apt-get update
@@ -237,7 +237,7 @@ EOF
 
 sudo chmod 755 /lib/systemd/system/flexget.service
 sudo systemctl enable flexget
-$HomeFolder/flexget/bin/flexget trakt auth $TraktUsername
+$HomeFolder/flexget/bin/flexget trakt auth $TraktUser
 fi
 
 


### PR DESCRIPTION
I hope this doesn't sound too harsh; I'm not great with words and everything below had to be addressed before I could get this script to run properly.

There's several instances of variables not being expanded, or inviting problems caused by symbols in user input, due to the incorrect use of quotes.

If quoting a variable that is to be expanded, double-quotes MUST be used. Single quotes lead to literal text. It's also generally good practice to enclose user input fields in single quotes so that if they use characters which have a special meaning to the shell, the characters are still handled as a literal string.

You have an error in your variable naming; in one instance of trying to use the TraktUser variable you instead use TraktUsername which does not exist. There's also an instance of SyncThing being mis-spelled.

You're using an obsolete invocation for system service control that is not supported by current Debian-derived distributions. systemctl is the base command, followed by the action, followed by the service.

You also appear to be generally lacking any checks for if operations succeeded. This can be quite dangerous. You should be checking exit codes or otherwise verifying if operations were successful.

I would recommend the wonderful terminal application Shellcheck. It's basically a syntax checker for shell scripting. Not only does it check for issues, it has unique numerical ID's for each which you can then lookup on the project's wiki for more information.